### PR TITLE
Add Placeholder for Organization Index Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import DiningCommonsIndexPage from "main/pages/DiningCommons/DiningCommonsIndexP
 import DiningCommonsCreatePage from "main/pages/DiningCommons/DiningCommonsCreatePage";
 import DiningCommonsEditPage from "main/pages/DiningCommons/DiningCommonsEditPage";
 
+import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
 
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
@@ -55,6 +56,13 @@ function App() {
             <>
               <Route exact path="/diningCommons/create" element={<DiningCommonsCreatePage />} />
               <Route exact path="/diningCommons/edit/:code" element={<DiningCommonsEditPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/organization/list" element={<UCSBOrganizationsIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationsIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSB Organizations</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -260,6 +260,30 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId("appnavbar-organization-list")).toBeInTheDocument() );
 
     });
+
+    test("renders the organization menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-organization-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-organization-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-organization-list/)).toBeInTheDocument() );
+
+    });
    
 });
 

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("UCSBOrganizationsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+


### PR DESCRIPTION
This PR implements a placeholder page for the UCSB Organizations index page `organization/list` when the "List Organizations" option is selected under the UCSB Organization drop down menu. The corresponding tests are also implemented providing 100% line coverage. 

The index page should look like the following 
![image](https://user-images.githubusercontent.com/75236585/200963215-bb053c9f-cea9-4508-a4b6-4e7564f71d2c.png)


Closes #28 
