### PR TITLE
UCSBOrganizationsTable implementation (with delete), storybook, and connecting to index page

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationsFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationsFixtures.js
@@ -1,0 +1,31 @@
+const ucsbOrganizationsFixtures = {
+    oneOrganization: {
+        "orgCode": "VSA",
+        "orgTranslationShort": "Viet Student Association",
+        "orgTranslation": "Vietnamese Student Association",
+        "inactive": false
+    },
+    threeOrganizations: [
+        {
+            "orgCode": "VSA",
+            "orgTranslationShort": "Viet Student Association",
+            "orgTranslation": "Vietnamese Student Association",
+            "inactive": false
+        },
+        {
+            "orgCode": "IEEE",
+            "orgTranslationShort": "Electrical and Electronics Engineers",
+            "orgTranslation": "Institute of Electrical and Electronics Engineers",
+            "inactive": true
+        },
+        {
+            "orgCode": "EWB",
+            "orgTranslationShort": "Engineers w/o Borders",
+            "orgTranslation": "Engineers Without Borders",
+            "inactive": false
+        }
+    ]
+};
+
+
+export { ucsbOrganizationsFixtures };

--- a/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
+++ b/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
@@ -1,27 +1,27 @@
-import OurTable from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
 // import { useNavigate } from "react-router-dom";
-// import { hasRole } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
-export default function UCSBOrganizationsTable({ organizations, _currentUser }) {
+export default function UCSBOrganizationsTable({ organizations, currentUser }) {
 
     // const navigate = useNavigate();
 
     // const editCallback = (cell) => {
-    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    //     navigate(`/UCSBOrganizations/edit/${cell.row.values.id}`)
     // }
 
     // Stryker disable all : hard to test for query caching
-    // const deleteMutation = useBackendMutation(
-    //     cellToAxiosParamsDelete,
-    //     { onSuccess: onDeleteSuccess },
-    //     ["/api/ucsbdates/all"]
-    // );
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsbdates/all"]
+    );
     // Stryker enable all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
 
 
@@ -45,15 +45,14 @@ export default function UCSBOrganizationsTable({ organizations, _currentUser }) 
         }
     ];
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
-    // ];
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable")
+        ButtonColumn("Delete", "danger", deleteCallback, "UCSBOrganizationsTable")
+    ];
 
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
-    const columnsToDisplay = columns;
 
     return <OurTable
         data={organizations}

--- a/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
+++ b/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
@@ -1,0 +1,63 @@
+import OurTable from "main/components/OurTable";
+// import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+// import { useNavigate } from "react-router-dom";
+// import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBOrganizationsTable({ organizations, _currentUser }) {
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    // const deleteMutation = useBackendMutation(
+    //     cellToAxiosParamsDelete,
+    //     { onSuccess: onDeleteSuccess },
+    //     ["/api/ucsbdates/all"]
+    // );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+
+    const columns = [
+        {
+            Header: 'Code',
+            accessor: 'orgCode', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Short Translation',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'Full Translation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'Inactive?',
+            id : 'inactive', // needed for tests
+            accessor: (row, _rowIndex) => String(row.inactive) // to show boolean values
+        }
+    ];
+
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+    // ];
+
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={organizations}
+        columns={columnsToDisplay}
+        testid={"UCSBOrganizationsTable"}
+    />;
+};

--- a/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
+++ b/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
@@ -1,6 +1,6 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBOrganizationsUtils"
 // import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
@@ -16,7 +16,7 @@ export default function UCSBOrganizationsTable({ organizations, currentUser }) {
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/ucsbdates/all"]
+        ["/api/UCSBOrganization/all"]
     );
     // Stryker enable all 
 
@@ -45,10 +45,12 @@ export default function UCSBOrganizationsTable({ organizations, currentUser }) {
         }
     ];
 
+    const testid = "UCSBOrganizationsTable";
+
     const columnsIfAdmin = [
         ...columns,
         // ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable")
-        ButtonColumn("Delete", "danger", deleteCallback, "UCSBOrganizationsTable")
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
@@ -57,6 +59,6 @@ export default function UCSBOrganizationsTable({ organizations, currentUser }) {
     return <OurTable
         data={organizations}
         columns={columnsToDisplay}
-        testid={"UCSBOrganizationsTable"}
+        testid={testid}
     />;
 };

--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
@@ -1,13 +1,28 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationsTable from 'main/components/UCSBOrganizations/UCSBOrganizationsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function UCSBOrganizationsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: organizations, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/UCSBOrganization/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/UCSBOrganization/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>UCSB Organizations</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <UCSBOrganizationsTable organizations={organizations} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/UCSBOrganizationsUtils.js
+++ b/frontend/src/main/utils/UCSBOrganizationsUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBOrganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
+

--- a/frontend/src/stories/components/UCSBOrganizations/UCSBOrganizationsTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganizations/UCSBOrganizationsTable.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import UCSBOrganizationsTable from "main/components/UCSBOrganizations/UCSBOrganizationsTable";
+import { ucsbOrganizationsFixtures } from 'fixtures/ucsbOrganizationsFixtures';
+
+export default {
+    title: 'components/UCSBOranizations/UCSBOrganizationsTable',
+    component: UCSBOrganizationsTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    organizations: []
+};
+
+export const threeOrganizations = Template.bind({});
+
+threeOrganizations.args = {
+    organizations: ucsbOrganizationsFixtures.threeOrganizations
+};
+
+

--- a/frontend/src/tests/components/UCSBOrganizations/UCSBOrganizationsTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganizations/UCSBOrganizationsTable.test.js
@@ -1,0 +1,127 @@
+import {  render } from "@testing-library/react";
+import { ucsbOrganizationsFixtures } from "fixtures/ucsbOrganizationsFixtures";
+import UCSBOrganizationsTable from "main/components/UCSBOranizations/UCSBOrganizationsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsTable ucsbOrganizations={ucsbOrganizationsFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    const expectedHeaders = ['Code',  'Short Translation', 'Full Translation','Inactive?'];
+    const expectedFields = ['orgCode', 'orgTranslationShort', 'orgTranslation', 'inactive'];
+    const testId = "UCSBOrganizationsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra");
+    expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
+    expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("De La Guerra");
+    expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Ortega");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <UCSBDatesTable diningCommons={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`UCSBDatesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+  //   const editButton = getByTestId(`UCSBDatesTable-cell-row-0-col-Edit-button`);
+  //   expect(editButton).toBeInTheDocument();
+    
+  //   fireEvent.click(editButton);
+
+  //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
+
+  // });
+
+
+});
+

--- a/frontend/src/tests/components/UCSBOrganizations/UCSBOrganizationsTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganizations/UCSBOrganizationsTable.test.js
@@ -1,6 +1,6 @@
 import {  render } from "@testing-library/react";
 import { ucsbOrganizationsFixtures } from "fixtures/ucsbOrganizationsFixtures";
-import UCSBOrganizationsTable from "main/components/UCSBOranizations/UCSBOrganizationsTable";
+import UCSBOrganizationsTable from "main/components/UCSBOrganizations/UCSBOrganizationsTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
     useNavigate: () => mockedNavigate
 }));
 
-describe("UCSBOrganizationTable tests", () => {
+describe("UCSBOrganizationsTable tests", () => {
   const queryClient = new QueryClient();
 
 
@@ -23,7 +23,7 @@ describe("UCSBOrganizationTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+          <UCSBOrganizationsTable organizations={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -35,7 +35,7 @@ describe("UCSBOrganizationTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+          <UCSBOrganizationsTable organizations={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -48,7 +48,7 @@ describe("UCSBOrganizationTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBOrganizationsTable ucsbOrganizations={[]} currentUser={currentUser} />
+          <UCSBOrganizationsTable organizations={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -62,7 +62,7 @@ describe("UCSBOrganizationTable tests", () => {
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBOrganizationsTable ucsbOrganizations={ucsbOrganizationsFixtures.threeOrganizations} currentUser={currentUser} />
+          <UCSBOrganizationsTable organizations={ucsbOrganizationsFixtures.threeOrganizations} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -83,10 +83,10 @@ describe("UCSBOrganizationTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra");
-    expect(getByTestId(`${testId}-cell-row-1-col-code`)).toHaveTextContent("ortega");
-    expect(getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("De La Guerra");
-    expect(getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Ortega");
+    expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("IEEE");
+    expect(getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("Viet Student Association");
+    expect(getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`)).toHaveTextContent("Electrical and Electronics Engineers");
 
     // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     // expect(editButton).toBeInTheDocument();

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
@@ -1,21 +1,59 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationsFixtures } from "fixtures/ucsbOrganizationsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import _mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("UCSBOrganizationsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "UCSBOrganizationsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -23,8 +61,147 @@ describe("UCSBOrganizationsIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+
+
     });
 
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders three organizations without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, ucsbOrganizationsFixtures.threeOrganizations);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA"); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("IEEE");
+        expect(getByTestId(`${testId}-cell-row-2-col-orgCode`)).toHaveTextContent("EWB");
+
+    });
+
+    test("renders three organizations without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, ucsbOrganizationsFixtures.threeOrganizations);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA"); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("IEEE");
+        expect(getByTestId(`${testId}-cell-row-2-col-orgCode`)).toHaveTextContent("EWB");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").timeout();
+
+        const { queryByTestId, getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
+
+        const expectedHeaders = ['Code', 'Short Translation', 'Full Translation', 'Inactive?'];
+    
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-orgCode`)).not.toBeInTheDocument();
+    });
+
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/all").reply(200, ucsbOrganizationsFixtures.threeOrganizations);
+        axiosMock.onDelete("/api/UCSBOrganization", {params: {orgCode: "VSA"}}).reply(200, "Organization with orgCode VSA was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA"); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Organization with orgCode VSA was deleted") });
+
+    });
+
+    // test("test what happens when you click edit as an admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/ucsbdiningcommons/all").reply(200, diningCommonsFixtures.threeCommons);
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <UCSBOrganizationsIndexPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
+
+    //     expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+
+
+    //     const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    //     expect(editButton).toBeInTheDocument();
+       
+    //     fireEvent.click(editButton);
+
+    //     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningCommons/edit/de-la-guerra'));
+
+    // });
+
+
 });
-
-

--- a/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
+++ b/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/UCSBOrganizationsUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBOrganizationsUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { orgCode: "VSA" } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/UCSBOrganization",
+                method: "DELETE",
+                params: { orgCode: "VSA" }
+            });
+        });
+
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
## Overview

This PR implements the UCSBOrganizationsTable, connecting with the RESTful API of UCSBOrganization in our database. The table is located in the `organization/list` directory of the site which is the index page. Below is an example of a filled out UCSBOrganizationsTable 

<img width="1196" alt="Screen Shot 2022-11-10 at 10 36 05 AM" src="https://user-images.githubusercontent.com/75236585/201178609-58c2a034-9cef-4dba-9e20-c0f7415ce3fe.png">

## Details

This PR allows logged in users to see the following information about UCSB Organizations: Code, Short Translation, Full Translation, Inactive?

Logged in admin users are able to see the delete column which allows admins to use the `UCSBOrganization/delete` endpoint of the backend. When pressed, the database deletes the corresponding entry and the front end updates the table accordingly.

Storybook and tests for the index page and table are implemented, along with all of its utilities, resulting in 100% line coverage and 100% mutations killed.

## Covers

This PR closes #29 #30 #31 . Multiple issues are covered because each issue allowed me to further test my implementations (i.e connecting database to index page)